### PR TITLE
Add schema and model for single resume document

### DIFF
--- a/backend/controllers/resume/resume-model.js
+++ b/backend/controllers/resume/resume-model.js
@@ -1,0 +1,6 @@
+import mongoose from "mongoose";
+
+import resume_schema from "./resume-schema.js";
+
+const resume_model = mongoose.model("ResumeModel", resume_schema);
+export default resume_model;

--- a/backend/controllers/resume/resume-schema.js
+++ b/backend/controllers/resume/resume-schema.js
@@ -1,0 +1,60 @@
+import mongoose from "mongoose";
+
+const MonthYearDate = new mongoose.Schema({
+  month: String,
+  year: String,
+});
+
+const Education = new mongoose.Schema({
+  name: String,
+  location: String,
+  degree: String,
+  from: MonthYearDate,
+  to: MonthYearDate,
+  expected_graduation: MonthYearDate,
+  details: String,
+  score: String,
+});
+
+const TechnicalSkills = new mongoose.Schema({
+  header: String,
+  skills: [String],
+});
+
+const WorkExperience = new mongoose.Schema({
+  name: String,
+  location: String,
+  role: String,
+  from: MonthYearDate,
+  to: MonthYearDate,
+  details: String,
+});
+
+const Projects = new mongoose.Schema({
+  name: String,
+  github_url: String,
+  from: MonthYearDate,
+  to: MonthYearDate,
+  details: String,
+});
+
+const resume_schema = new mongoose.Schema(
+  {
+    first_name: String,
+    last_name: String,
+    email_id: String,
+    linkedin_url: String,
+    github_url: String,
+    location: String,
+    phone: String,
+    education: [Education],
+    technical_skills: [TechnicalSkills],
+    work_experience: [WorkExperience],
+    projects: [Projects],
+  },
+  {
+    collection: "resume",
+  }
+);
+
+export default resume_schema;

--- a/backend/controllers/resume/resume-schema.js
+++ b/backend/controllers/resume/resume-schema.js
@@ -5,56 +5,135 @@ const MonthYearDate = new mongoose.Schema({
   year: String,
 });
 
+const Location = new mongoose.Schema({
+  address: String,
+  postalCode: String,
+  city: String,
+  countryCode: String,
+  region: String,
+});
+
+const Profile = new mongoose.Schema({
+  network: String,
+  username: String,
+  url: String,
+});
+
+const Basics = new mongoose.Schema({
+  name: String,
+  label: String,
+  image: String,
+  email: String,
+  phone: String,
+  url: String,
+  summary: String,
+  location: Location,
+  profiles: [Profile],
+});
+
+const Work = new mongoose.Schema({
+  name: String,
+  position: String,
+  url: String,
+  startDate: MonthYearDate,
+  endDate: MonthYearDate,
+  summary: [String],
+  highlights: [String],
+});
+
+const Volunteer = new mongoose.Schema({
+  organization: String,
+  position: String,
+  url: String,
+  startDate: MonthYearDate,
+  endDate: MonthYearDate,
+  summary: [String],
+  highlights: [String],
+});
+
 const Education = new mongoose.Schema({
-  name: String,
-  location: String,
-  degree: String,
-  from: MonthYearDate,
-  to: MonthYearDate,
-  expected_graduation: MonthYearDate,
-  details: String,
+  institution: String,
+  url: String,
+  area: String,
+  studyType: String,
+  startDate: MonthYearDate,
+  endDate: MonthYearDate,
   score: String,
+  courses: [String],
 });
 
-const TechnicalSkills = new mongoose.Schema({
-  header: String,
-  skills: [String],
+const Award = new mongoose.Schema({
+  title: String,
+  date: MonthYearDate,
+  awarder: String,
+  summary: String,
 });
 
-const WorkExperience = new mongoose.Schema({
+const Certificate = new mongoose.Schema({
   name: String,
-  location: String,
-  role: String,
-  from: MonthYearDate,
-  to: MonthYearDate,
-  details: String,
+  date: MonthYearDate,
+  issuer: String,
+  url: String,
 });
 
-const Projects = new mongoose.Schema({
+const Publication = new mongoose.Schema({
   name: String,
-  github_url: String,
-  from: MonthYearDate,
-  to: MonthYearDate,
-  details: String,
+  publisher: String,
+  releaseDate: MonthYearDate,
+  url: String,
+  summary: String,
+});
+
+const Skill = new mongoose.Schema({
+  name: String,
+  level: String,
+  keywords: [String],
+});
+
+const Language = new mongoose.Schema({
+  language: String,
+  fluency: String,
+});
+
+const Interest = new mongoose.Schema({
+  name: String,
+  keywords: [String],
+});
+
+const Reference = new mongoose.Schema({
+  name: String,
+  reference: String,
+});
+
+const Project = new mongoose.Schema({
+  name: String,
+  description: String,
+  highlights: [String],
+  keywords: [String],
+  startDate: MonthYearDate,
+  endDate: MonthYearDate,
+  url: String,
+  roles: [String],
+  entity: String,
+  type: String,
 });
 
 const resume_schema = new mongoose.Schema(
   {
-    first_name: String,
-    last_name: String,
-    email_id: String,
-    linkedin_url: String,
-    github_url: String,
-    location: String,
-    phone: String,
+    basics: Basics,
+    work: [Work],
+    volunteer: [Volunteer],
     education: [Education],
-    technical_skills: [TechnicalSkills],
-    work_experience: [WorkExperience],
-    projects: [Projects],
+    awards: [Award],
+    certificates: [Certificate],
+    publications: [Publication],
+    skills: [Skill],
+    languages: [Language],
+    interests: [Interest],
+    references: [Reference],
+    projects: [Project],
   },
-  {
-    collection: "resume",
-  }
+  { collection: "resume" }
 );
 
 export default resume_schema;


### PR DESCRIPTION
Closes #18 

**Implementation**

1. Added a schema for a single resume document based on the details in [my resume](https://github.com/Documentive/TemplateBuddy/files/11186161/Siddhartha_Dhar_Choudhury_Resume.pdf)
2. Added a model for the schema.

**Revision 2**

1. Moved from the existing schema to standard [JSON Resume](https://jsonresume.org/schema/) schema. 