### PR TITLE
Add basic skeleton for the Personal Details section

### DIFF
--- a/frontend/src/components/LeftPanel/Header.js
+++ b/frontend/src/components/LeftPanel/Header.js
@@ -3,7 +3,7 @@ import { BsFillSunFill, BsFillMoonFill } from "react-icons/bs";
 
 const Header = () => {
   return (
-    <div className="w-full h-16 border-blue-800 border-2 flex justify-end items-center px-8">
+    <div className="w-full h-16 flex justify-end items-center px-8">
       {/* TODO: Need to complete the toggle theme functionality */}
       <p>Toggle Theme</p>
       <div className="flex ml-4">

--- a/frontend/src/components/LeftPanel/LeftPanel.js
+++ b/frontend/src/components/LeftPanel/LeftPanel.js
@@ -5,11 +5,11 @@ import Basics from "./sections/Basics";
 
 const LeftPanel = () => {
   return (
-    <div className="w-full h-full border-2 border-solid border-red-300 flex flex-row">
+    <div className="w-full h-full flex flex-row">
       <NavBar />
       <div className="w-full h-full flex flex-col">
         <Header />
-        <div className="w-full h-full">
+        <div className="w-full h-full overflow-y-scroll">
           {/* All resume sections go here
           Each section gets its own component. To be created in the sections folder */}
           <Basics />

--- a/frontend/src/components/LeftPanel/LeftPanel.js
+++ b/frontend/src/components/LeftPanel/LeftPanel.js
@@ -1,6 +1,7 @@
 import React from "react";
 import NavBar from "./NavBar";
 import Header from "./Header";
+import Basics from "./sections/Basics";
 
 const LeftPanel = () => {
   return (
@@ -11,7 +12,7 @@ const LeftPanel = () => {
         <div className="w-full h-full">
           {/* All resume sections go here
           Each section gets its own component. To be created in the sections folder */}
-          Input
+          <Basics />
         </div>
       </div>
     </div>

--- a/frontend/src/components/LeftPanel/NavBar.js
+++ b/frontend/src/components/LeftPanel/NavBar.js
@@ -6,7 +6,7 @@ import { navLinks } from "../../config/navbarConstants";
 const NavBar = () => {
   
   return (
-    <div className="border-2 border-black w-20 flex flex-col items-center">
+    <div className="w-20 flex flex-col items-center">
       {/* TODO: Need to prepare a logo and favicon */}
       <div className="w-full h-16 border-2 border-orange-300">Logo</div>
       <div className="h-4/6 my-auto flex flex-col justify-evenly items-center">

--- a/frontend/src/components/LeftPanel/NavBar.js
+++ b/frontend/src/components/LeftPanel/NavBar.js
@@ -4,13 +4,11 @@ import { IconButton, Tooltip, Fade } from "@mui/material";
 import { navLinks } from "../../config/navbarConstants";
 
 const NavBar = () => {
-  
   return (
     <div className="w-20 flex flex-col items-center">
       {/* TODO: Need to prepare a logo and favicon */}
       <div className="w-full h-16 border-2 border-orange-300">Logo</div>
       <div className="h-4/6 my-auto flex flex-col justify-evenly items-center">
-
         {navLinks.map(({ id, title, ariaLabel, icon }) => (
           <Tooltip
             key={id}

--- a/frontend/src/components/LeftPanel/sections/Basics.js
+++ b/frontend/src/components/LeftPanel/sections/Basics.js
@@ -13,7 +13,7 @@ const Basics = () => {
         </div>
         <p className="text-3xl">Personal Details</p>
       </div>
-      <IconButton component="button">
+      <IconButton component="label">
         <Tooltip title="Upload Image">
           <Avatar sx={{ width: 96, height: 96 }} />
         </Tooltip>
@@ -25,11 +25,11 @@ const Basics = () => {
       <TextField fullWidth label="Portfolio Link" />
       <TextField fullWidth label="Job Title" />
       <TextField fullWidth label="Summary" multiline rows={5} />
-      <hr className="my-3 border-red-800 w-4/5 mx-auto"/>
+      <hr className="my-3 border-red-800 w-4/5 mx-auto" />
       <Location />
-      <hr className="my-3 border-red-800 w-4/5 mx-auto"/>
+      <hr className="my-3 border-red-800 w-4/5 mx-auto" />
       <Socials />
-      <hr className="my-3 border-red-800 w-4/5 mx-auto"/>
+      <hr className="my-3 border-red-800 w-4/5 mx-auto" />
     </div>
   );
 };

--- a/frontend/src/components/LeftPanel/sections/Basics.js
+++ b/frontend/src/components/LeftPanel/sections/Basics.js
@@ -1,9 +1,18 @@
 import { TextField, Avatar, IconButton, Tooltip } from "@mui/material";
 import React from "react";
+import Location from "./Location";
+import { Person } from "@mui/icons-material";
+import Socials from "./Socials";
 
 const Basics = () => {
   return (
     <div>
+      <div className="flex w-full items-center gap-3 mb-4">
+        <div className="ml-2">
+          <Person />
+        </div>
+        <p className="text-3xl">Personal Details</p>
+      </div>
       <IconButton component="button">
         <Tooltip title="Upload Image">
           <Avatar sx={{ width: 96, height: 96 }} />
@@ -16,6 +25,11 @@ const Basics = () => {
       <TextField fullWidth label="Portfolio Link" />
       <TextField fullWidth label="Job Title" />
       <TextField fullWidth label="Summary" multiline rows={5} />
+      <hr className="my-3 border-red-800 w-4/5 mx-auto"/>
+      <Location />
+      <hr className="my-3 border-red-800 w-4/5 mx-auto"/>
+      <Socials />
+      <hr className="my-3 border-red-800 w-4/5 mx-auto"/>
     </div>
   );
 };

--- a/frontend/src/components/LeftPanel/sections/Basics.js
+++ b/frontend/src/components/LeftPanel/sections/Basics.js
@@ -1,0 +1,23 @@
+import { TextField, Avatar, IconButton, Tooltip } from "@mui/material";
+import React from "react";
+
+const Basics = () => {
+  return (
+    <div>
+      <IconButton component="button">
+        <Tooltip title="Upload Image">
+          <Avatar sx={{ width: 96, height: 96 }} />
+        </Tooltip>
+        <input hidden type="file" accept="image/*" />
+      </IconButton>
+      <TextField fullWidth label="Full Name" />
+      <TextField fullWidth label="Email" />
+      <TextField fullWidth label="Phone Number" />
+      <TextField fullWidth label="Portfolio Link" />
+      <TextField fullWidth label="Job Title" />
+      <TextField fullWidth label="Summary" multiline rows={5} />
+    </div>
+  );
+};
+
+export default Basics;

--- a/frontend/src/components/LeftPanel/sections/Location.js
+++ b/frontend/src/components/LeftPanel/sections/Location.js
@@ -1,0 +1,23 @@
+import { Apartment } from "@mui/icons-material";
+import { TextField } from "@mui/material";
+import React from "react";
+
+const Location = () => {
+  return (
+    <div>
+      <div className="flex w-full items-center gap-3 mb-4">
+        <div className="ml-2">
+          <Apartment />
+        </div>
+        <p className="text-3xl">Location</p>
+      </div>
+      <TextField fullWidth label="Address" />
+      <TextField fullWidth label="City" />
+      <TextField fullWidth label="Region" />
+      <TextField fullWidth label="Country" />
+      <TextField fullWidth label="Postal Code" />
+    </div>
+  );
+};
+
+export default Location;

--- a/frontend/src/components/LeftPanel/sections/Socials.js
+++ b/frontend/src/components/LeftPanel/sections/Socials.js
@@ -1,0 +1,27 @@
+import { AlternateEmail, Public } from '@mui/icons-material'
+import { InputAdornment, TextField } from '@mui/material'
+import React from 'react'
+
+const Socials = () => {
+  return (
+    <div>
+        <div className="flex w-full items-center gap-3 mb-4">
+        <div className="ml-2">
+          <Public />
+        </div>
+        <p className="text-3xl">Socials</p>
+      </div>
+      <TextField fullWidth label="Platform" />
+      <TextField fullWidth label="Username" InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <AlternateEmail />
+            </InputAdornment>
+          ),
+        }} />
+      <TextField fullWidth label="Website" />
+    </div>
+  )
+}
+
+export default Socials

--- a/frontend/src/components/LeftPanel/sections/Socials.js
+++ b/frontend/src/components/LeftPanel/sections/Socials.js
@@ -1,27 +1,31 @@
-import { AlternateEmail, Public } from '@mui/icons-material'
-import { InputAdornment, TextField } from '@mui/material'
-import React from 'react'
+import { AlternateEmail, Public } from "@mui/icons-material";
+import { InputAdornment, TextField } from "@mui/material";
+import React from "react";
 
 const Socials = () => {
   return (
     <div>
-        <div className="flex w-full items-center gap-3 mb-4">
+      <div className="flex w-full items-center gap-3 mb-4">
         <div className="ml-2">
           <Public />
         </div>
         <p className="text-3xl">Socials</p>
       </div>
       <TextField fullWidth label="Platform" />
-      <TextField fullWidth label="Username" InputProps={{
+      <TextField
+        fullWidth
+        label="Username"
+        InputProps={{
           startAdornment: (
             <InputAdornment position="start">
               <AlternateEmail />
             </InputAdornment>
           ),
-        }} />
+        }}
+      />
       <TextField fullWidth label="Website" />
     </div>
-  )
-}
+  );
+};
 
-export default Socials
+export default Socials;


### PR DESCRIPTION
Closes #3 

Implementation
- Add basic skeleton for the users details
- Add basic skeleton for the user's address
- Add basic skeleton for the user's social profile (needs JS implementation to add more)
- Add a horizontal rule separation between different sections
- Remove most borders from the left panel to observe the design