### PR TITLE
[BLOCKER] Add controller setup and push basics to only resume present

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,7 +1,13 @@
 import express from "express";
 import cors from "cors";
+import mongoose from "mongoose";
 
 import HealthController from "./controllers/health/health-controller.js";
+import ResumeController from "./controllers/resume/resume-controller.js";
+
+const CONNECTION_STRING =
+  process.env.DB_CONNECTION_STRING || "mongodb://localhost:27017/TemplateBuddy";
+mongoose.connect(CONNECTION_STRING);
 
 const cors_options = {
   origin: "*",
@@ -13,5 +19,6 @@ app.use(cors(cors_options));
 app.use(express.json());
 
 HealthController(app);
+ResumeController(app);
 
 app.listen(process.env.PORT || 4000);

--- a/backend/controllers/resume/resume-controller.js
+++ b/backend/controllers/resume/resume-controller.js
@@ -1,0 +1,24 @@
+import * as resumeDao from "./resume-dao.js";
+
+const getSingletonResume = async () => {
+  let resumes = await resumeDao.getAllResumes();
+  if (resumes.length === 0) {
+    resumes = [await resumeDao.createEmptyResume()];
+  }
+
+  return resumes[0];
+};
+
+const putBasics = async (req, res) => {
+  const { basics } = req.body;
+  const resume = await getSingletonResume();
+  const id = resume._id;
+  const updatedResume = await resumeDao.updateBasicsById(id, basics);
+  return res.status(201).json({ updatedResume });
+};
+
+const ResumeController = (app) => {
+  app.put("/resume/basics", putBasics);
+};
+
+export default ResumeController;

--- a/backend/controllers/resume/resume-dao.js
+++ b/backend/controllers/resume/resume-dao.js
@@ -1,0 +1,19 @@
+import resumeModel from "./resume-model.js";
+
+export const createEmptyResume = () => {
+  return resumeModel.create({ basics: {} });
+};
+
+export const getAllResumes = () => {
+  return resumeModel.find();
+};
+
+export const updateBasicsById = (id, basics) => {
+  return resumeModel.findByIdAndUpdate(
+    id,
+    {
+      basics,
+    },
+    { new: true }
+  );
+};


### PR DESCRIPTION
Closes #55 

**Implementation**

1. Added a basic DAO for resume.
2. Since we do not have any users it is not possible to maintain multiple resumes, hence designed the API in such a way that it always works with the one and only document in the Mongo collection - resume.
3. Added a simple `PUT` endpoint `/resume/basics` to add or update basics information in Mongo. 

**NOTE**: This is a blocker since it has all the setup for subsequent endpoints, please prioritize merging this before the others. 