### PR TITLE
Add a generic endpoint to add/update all sections

### DIFF
--- a/backend/controllers/resume/resume-controller.js
+++ b/backend/controllers/resume/resume-controller.js
@@ -9,16 +9,21 @@ const getSingletonResume = async () => {
   return resumes[0];
 };
 
-const putBasics = async (req, res) => {
-  const { basics } = req.body;
+const putSection = async (req, res) => {
+  const { section_name } = req.params;
+  const { section } = req.body;
   const resume = await getSingletonResume();
   const id = resume._id;
-  const updatedResume = await resumeDao.updateBasicsById(id, basics);
+  const updatedResume = await resumeDao.updateSectionById(
+    id,
+    section_name,
+    section[section_name]
+  );
   return res.status(201).json({ updatedResume });
 };
 
 const ResumeController = (app) => {
-  app.put("/resume/basics", putBasics);
+  app.put("/resume/:section_name", putSection);
 };
 
 export default ResumeController;

--- a/backend/controllers/resume/resume-dao.js
+++ b/backend/controllers/resume/resume-dao.js
@@ -8,12 +8,9 @@ export const getAllResumes = () => {
   return resumeModel.find();
 };
 
-export const updateBasicsById = (id, basics) => {
-  return resumeModel.findByIdAndUpdate(
-    id,
-    {
-      basics,
-    },
-    { new: true }
-  );
+export const updateSectionById = (id, section_name, value) => {
+  let updateObj = {};
+  updateObj[section_name] = value;
+
+  return resumeModel.findByIdAndUpdate(id, updateObj, { new: true });
 };


### PR DESCRIPTION
Closes #56 
Closes #57 
Closes #58 
Closes #59 
Closes #60 
Closes #61 
Closes #62 
Closes #63 
Closes #64 
Closes #65 
Closes #66 

**Implementation**

1. All the updated felt repetitive to me, so I made it to a single section and a single generic `PUT` endpoint of the format: `/resume/:section_name`.
2. The body will look like:

```json
{
    "section": {
        <section-obj>
    }
}
```

Apologies about the branch name, I started work and then realized that a generic solution is possible. 