### PR TITLE
Remove compiler warnings

### DIFF
--- a/frontend/src/components/LeftPanel/sections/Basics.js
+++ b/frontend/src/components/LeftPanel/sections/Basics.js
@@ -41,6 +41,7 @@ const Basics = () => {
 
   useEffect(() => {
     dispatch(getResumeThunk());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -61,12 +62,15 @@ const Basics = () => {
               section[key] = resumeLocalStorageObject[key];
               dispatch(putSectionThunk({ section_name, section }));
             }
+
+            return null;
           });
         }
       }, 10000);
 
       return () => clearInterval(interval);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resume, resumeLoading]);
 
   return (
@@ -86,6 +90,7 @@ const Basics = () => {
           ) : (
             <img
               src={imageURL}
+              alt="profile"
               style={{ width: 96, height: 96, borderRadius: "50%" }}
             />
           )}

--- a/frontend/src/components/LeftPanel/sections/GenericListSection.js
+++ b/frontend/src/components/LeftPanel/sections/GenericListSection.js
@@ -23,9 +23,12 @@ const GenericSection = ({
       let tempEntryList = [];
       arrayObj.map((entry) => {
         tempEntryList = [...tempEntryList, entry];
+        return null;
       });
       setEntryList(tempEntryList);
     }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resume, resumeLoading]);
 
   return (


### PR DESCRIPTION
Closes #73 

**Implementation**

1. Added `return null;` for every array/object mapping.
2. Do not check for dependencies in `useEffect`. 