### PR TITLE
[END-TO-END-TEST-REQUIRED] Edit fields

### DIFF
--- a/backend/controllers/resume/resume-schema.js
+++ b/backend/controllers/resume/resume-schema.js
@@ -34,6 +34,7 @@ const Basics = new mongoose.Schema({
 const Work = new mongoose.Schema({
   name: String,
   position: String,
+  location: String,
   url: String,
   startDate: MonthYearDate,
   endDate: MonthYearDate,

--- a/frontend/src/components/LeftPanel/LeftPanel.js
+++ b/frontend/src/components/LeftPanel/LeftPanel.js
@@ -22,51 +22,51 @@ const LeftPanel = () => {
     {
       type: "Basics",
     },
-    // {
-    //   type: "GenericSection",
-    //   config: educationSectionConfig,
-    // },
+    {
+      type: "GenericSection",
+      config: educationSectionConfig,
+    },
     {
       type: "GenericSection",
       config: workExperienceSectionConfig,
     },
-    // {
-    //   type: "GenericSection",
-    //   config: projectsSectionConfig,
-    // },
-    // {
-    //   type: "GenericSection",
-    //   config: skillsSectionConfig,
-    // },
-    // {
-    //   type: "GenericSection",
-    //   config: certificationsSectionConfig,
-    // },
-    // {
-    //   type: "GenericSection",
-    //   config: languagesSectionConfig,
-    // },
-    // {
-    //   type: "GenericSection",
-    //   config: publicationsSectionConfig,
-    // },
-    // {
-    //   type: "GenericSection",
-    //   config: awardsSectionConfig,
-    // },
-    // {
-    //   type: "GenericSection",
-    //   config: interestsSectionConfig,
-    // },
-    // {
-    //   type: "GenericSection",
-    //   config: volunteerSectionConfig,
-    // },
+    {
+      type: "GenericSection",
+      config: projectsSectionConfig,
+    },
+    {
+      type: "GenericSection",
+      config: skillsSectionConfig,
+    },
+    {
+      type: "GenericSection",
+      config: certificationsSectionConfig,
+    },
+    {
+      type: "GenericSection",
+      config: languagesSectionConfig,
+    },
+    {
+      type: "GenericSection",
+      config: publicationsSectionConfig,
+    },
+    {
+      type: "GenericSection",
+      config: awardsSectionConfig,
+    },
+    {
+      type: "GenericSection",
+      config: interestsSectionConfig,
+    },
+    {
+      type: "GenericSection",
+      config: volunteerSectionConfig,
+    },
 
-    // {
-    //   type: "GenericSection",
-    //   config: referencesSectionConfig,
-    // },
+    {
+      type: "GenericSection",
+      config: referencesSectionConfig,
+    },
   ];
 
   return (

--- a/frontend/src/components/LeftPanel/LeftPanel.js
+++ b/frontend/src/components/LeftPanel/LeftPanel.js
@@ -22,51 +22,51 @@ const LeftPanel = () => {
     {
       type: "Basics",
     },
-    {
-      type: "GenericSection",
-      config: educationSectionConfig,
-    },
+    // {
+    //   type: "GenericSection",
+    //   config: educationSectionConfig,
+    // },
     {
       type: "GenericSection",
       config: workExperienceSectionConfig,
     },
-    {
-      type: "GenericSection",
-      config: projectsSectionConfig,
-    },
-    {
-      type: "GenericSection",
-      config: skillsSectionConfig,
-    },
-    {
-      type: "GenericSection",
-      config: certificationsSectionConfig,
-    },
-    {
-      type: "GenericSection",
-      config: languagesSectionConfig,
-    },
-    {
-      type: "GenericSection",
-      config: publicationsSectionConfig,
-    },
-    {
-      type: "GenericSection",
-      config: awardsSectionConfig,
-    },
-    {
-      type: "GenericSection",
-      config: interestsSectionConfig,
-    },
-    {
-      type: "GenericSection",
-      config: volunteerSectionConfig,
-    },
+    // {
+    //   type: "GenericSection",
+    //   config: projectsSectionConfig,
+    // },
+    // {
+    //   type: "GenericSection",
+    //   config: skillsSectionConfig,
+    // },
+    // {
+    //   type: "GenericSection",
+    //   config: certificationsSectionConfig,
+    // },
+    // {
+    //   type: "GenericSection",
+    //   config: languagesSectionConfig,
+    // },
+    // {
+    //   type: "GenericSection",
+    //   config: publicationsSectionConfig,
+    // },
+    // {
+    //   type: "GenericSection",
+    //   config: awardsSectionConfig,
+    // },
+    // {
+    //   type: "GenericSection",
+    //   config: interestsSectionConfig,
+    // },
+    // {
+    //   type: "GenericSection",
+    //   config: volunteerSectionConfig,
+    // },
 
-    {
-      type: "GenericSection",
-      config: referencesSectionConfig,
-    },
+    // {
+    //   type: "GenericSection",
+    //   config: referencesSectionConfig,
+    // },
   ];
 
   return (

--- a/frontend/src/components/LeftPanel/constants/modes.js
+++ b/frontend/src/components/LeftPanel/constants/modes.js
@@ -1,0 +1,4 @@
+export const modes = {
+  ADD: "ADD",
+  EDIT: "EDIT",
+};

--- a/frontend/src/components/LeftPanel/sections/GenericListSection.js
+++ b/frontend/src/components/LeftPanel/sections/GenericListSection.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import GenericModal from "./modals/GenericListModal";
 import { Button, List, ListItem, ListItemText } from "@mui/material";
 import { useSelector } from "react-redux";
+import { modes } from "../constants/modes";
 
 const GenericSection = ({
   fieldsMap,
@@ -14,6 +15,8 @@ const GenericSection = ({
   const { resume, resumeLoading } = useSelector((state) => state.resume);
   let [openModal, setOpenModal] = useState(false);
   let [entryList, setEntryList] = useState([]);
+  let [modalMode, setModalMode] = useState(modes.ADD);
+  let [currentModalIdx, setCurrentModalIdx] = useState(-1);
 
   useEffect(() => {
     if (!resumeLoading && resume !== null) {
@@ -31,6 +34,12 @@ const GenericSection = ({
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resume, resumeLoading]);
+
+  const handleEditClick = (idx) => {
+    setOpenModal(true);
+    setCurrentModalIdx(idx);
+    setModalMode(modes.EDIT);
+  };
 
   return (
     <div>
@@ -57,6 +66,9 @@ const GenericSection = ({
         fieldName={fieldName}
         dbField={dbField}
         fieldGroups={fieldGroups}
+        modalMode={modalMode}
+        setModalMode={setModalMode}
+        currentModalIdx={currentModalIdx}
       />
       {Object.keys(entryList).length > 0 && (
         <>
@@ -65,6 +77,14 @@ const GenericSection = ({
               return (
                 <ListItem key={idx}>
                   <ListItemText>{entryList[entry][displayField]}</ListItemText>
+                  <Button
+                    variant="contained"
+                    onClick={() => {
+                      handleEditClick(idx);
+                    }}
+                  >
+                    Edit
+                  </Button>
                 </ListItem>
               );
             })}

--- a/frontend/src/components/LeftPanel/sections/modals/GenericListModal.js
+++ b/frontend/src/components/LeftPanel/sections/modals/GenericListModal.js
@@ -200,6 +200,16 @@ const GenericModal = ({
     return <ListItemText>{entry}</ListItemText>;
   };
 
+  const getBtnName = (field, entry, idx) => {
+    const key = `${field}-${entry}-${idx}`;
+
+    if (key in isEditingFieldEntryIdxMap) {
+      return "Save";
+    } else {
+      return "Edit";
+    }
+  };
+
   // Add the markup for the fields based on the fieldtype to the fieldDOM object
   Object.keys(fieldsMap).map((field) => {
     let value = fieldsMap[field];
@@ -292,7 +302,7 @@ const GenericModal = ({
                           editGenericListMapEntry(field, entry, idx);
                         }}
                       >
-                        Edit
+                        {getBtnName(field, entry, idx)}
                       </Button>
                     </ListItem>
                   );

--- a/frontend/src/components/LeftPanel/sections/modals/GenericListModal.js
+++ b/frontend/src/components/LeftPanel/sections/modals/GenericListModal.js
@@ -10,6 +10,7 @@ import {
   TextField,
 } from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers";
+import dayjs from "dayjs";
 import React, { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
 import { modes } from "../../constants/modes";
@@ -92,6 +93,15 @@ const GenericModal = ({
         arrayObj = arrayObj[dbField[i]];
       }
       setModalEntryObject(arrayObj[currentModalIdx]);
+
+      Object.keys(fieldsMap).map((field) => {
+        if (fieldsMap[field].type === "MultiEntryList") {
+          setGenericListMap({
+            ...genericListMap,
+            [field]: arrayObj[currentModalIdx][field],
+          });
+        }
+      });
     } else {
       setModalEntryObject({});
     }
@@ -120,6 +130,16 @@ const GenericModal = ({
     return modalEntryObject[fieldName] ? modalEntryObject[fieldName] : "";
   };
 
+  const getDateValue = (fieldName) => {
+    if (modalEntryObject[fieldName]) {
+      return dayjs(
+        `${modalEntryObject[fieldName].year}-${modalEntryObject[fieldName].month}-01`
+      );
+    }
+
+    return null;
+  };
+
   // Add the markup for the fields based on the fieldtype to the fieldDOM object
   Object.keys(fieldsMap).map((field) => {
     let value = fieldsMap[field];
@@ -134,6 +154,7 @@ const GenericModal = ({
               name={value.label.toLowerCase()}
               multiline
               rows={value.rows}
+              value={getValue(field)}
               onChange={(e) => onInputToField(e, field)}
               key={field}
             />
@@ -170,6 +191,7 @@ const GenericModal = ({
                   }
                 : {}
             }
+            value={getDateValue(field)}
             onChange={(d, e) => onInputToDatePicker(d, e, field)}
           />
         );

--- a/frontend/src/config/sectionConfig.js
+++ b/frontend/src/config/sectionConfig.js
@@ -92,7 +92,7 @@ export const workExperienceSectionConfig = {
       type: "TextField",
       label: "Location",
     },
-    role: {
+    position: {
       type: "TextField",
       label: "Role",
     },
@@ -110,14 +110,19 @@ export const workExperienceSectionConfig = {
       label: "Summary",
       rows: 5,
     },
+    highlights: {
+      type: "MultiEntryList",
+      label: "Highlights",
+    },
   },
   fieldName: "Work Experience",
   fieldIcon: <Work />,
   fieldGroups: [
-    ["name", "role"],
+    ["name", "position"],
     ["location"],
     ["startDate", "endDate"],
     ["summary"],
+    ["highlights"],
   ],
   displayField: "name",
   dbField: ["work"],


### PR DESCRIPTION
Closes #82 

**Implementation**

1. Introduce the concept of modes (ADD/EDIT).
2. Open the modal in either ADD or EDIT mode, ADD mode presents a clean modal with fields ready to take fresh input, EDIT mode on the other hand loads data based on the currently fetched resume schema. 
3. Maintain an index of lists (of modals) that can be passed to the modal so that it can extract relevant data while in EDIT mode.
4. Maintain two separate maps to identify edits made to the existing multi-entry text list. 
5. On updates push the updated object to the relevant position in the local storage resume copy, which can then be picked up by the diff checker (in Basics) and make PUT calls to the API to indicate new changes to be stored in DB. 

**Note**
- There was a lot of complex state manipulation, so chances are some things might break. I have tested it on my end, please perform an end-to-end test (starting with an empty resume, adding an entry, editing an entry, and checking if updates went through by reloading the page). You will have to run both the backend and mongo in order to do this. 

**Moving forward**

- Now that I think of it, a lot of logic for delete depends on this, so I am marking this issue as a blocker, and will start the delete issue once this is tested and merged. 