### PR TITLE
Add dark mode preference to cookies and load it from there

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "react-redux": "^8.0.5",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.9",
+        "universal-cookie": "^4.0.4",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -4475,6 +4476,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "node_modules/@types/eslint": {
       "version": "8.37.0",
@@ -17156,6 +17162,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/universalify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-redux": "^8.0.5",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.9",
+    "universal-cookie": "^4.0.4",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import { useEffect, useState } from "react";
 
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
+import Cookies from "universal-cookie";
 
 const store = configureStore({
   reducer: {
@@ -27,28 +28,40 @@ const App = () => {
   // To toggle themeswitch state
   const [darkMode, setDarkMode] = useState(false);
 
+  const cookies = new Cookies();
+
   // Set theme initially based on system preference, happens only once
   useEffect(() => {
-    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-      setDarkMode(true);
+    let savedDarkMode = cookies.get("darkMode") === "true";
+    if (savedDarkMode !== undefined) {
+      setDarkMode(savedDarkMode);
     } else {
-      setDarkMode(false);
+      let decision = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      setDarkMode(decision);
+      cookies.set("darkMode", decision, { path: "/" });
     }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Re-render only when theme is changed
   useEffect(() => {
     if (darkMode) {
       // Need to use data-attribute to toggle dark mode as css modules are hindering
-      document.documentElement.querySelector("body").setAttribute("data-mode", "dark");
+      document.documentElement
+        .querySelector("body")
+        .setAttribute("data-mode", "dark");
     } else {
-      document.documentElement.querySelector("body").removeAttribute("data-mode");
+      document.documentElement
+        .querySelector("body")
+        .removeAttribute("data-mode");
     }
   }, [darkMode]);
 
   // handle theme toggle
   const handleThemeToggle = () => {
     setDarkMode(!darkMode);
+    cookies.set("darkMode", !darkMode, { path: "/" });
   };
 
   const darkTheme = createTheme({


### PR DESCRIPTION
Closes #113 

**Implementation**

1. Store dark mode preference in cookies.
2. Check if any preference exists in cookies, otherwise fallback to system preference or the default white screen.
3. If it exists in cookies, then load the value from cookies. 