### PR TITLE
[READ-NOTE-BEFORE-MERGING] Add option to dump resume into JSON

### DIFF
--- a/frontend/src/components/LeftPanel/LeftPanel.js
+++ b/frontend/src/components/LeftPanel/LeftPanel.js
@@ -18,6 +18,7 @@ import {
 } from "../../config/sectionConfig";
 import { useDispatch, useSelector } from "react-redux";
 import { putSectionThunk } from "../../services/resume-thunk";
+import { Button } from "@mui/material";
 
 const LeftPanel = ({ check, handleThemeToggle }) => {
   let { resume, resumeLoading } = useSelector((state) => state.resume);
@@ -75,6 +76,44 @@ const LeftPanel = ({ check, handleThemeToggle }) => {
 
   const dispatch = useDispatch();
 
+  const removeKeyFromObject = (obj, key) => {
+    if (typeof obj !== "object" || obj === null) {
+      return obj;
+    }
+
+    if (Array.isArray(obj)) {
+      obj.forEach(function (item) {
+        removeKeyFromObject(item, key);
+      });
+    } else {
+      for (var prop in obj) {
+        if (obj.hasOwnProperty(prop)) {
+          if (prop === key) {
+            delete obj[prop];
+          } else {
+            removeKeyFromObject(obj[prop], key);
+          }
+        }
+      }
+    }
+
+    return obj;
+  };
+
+  const exportResumeToJSON = () => {
+    let resumeClone = JSON.parse(JSON.stringify(resume));
+    let cleanedResume = removeKeyFromObject(resumeClone, "_id");
+    cleanedResume = removeKeyFromObject(cleanedResume, "__v");
+    const resumeJSON = JSON.stringify(cleanedResume, null, 4);
+    const element = document.createElement("a");
+    const file = new Blob([resumeJSON], { type: "application/json" });
+    element.href = URL.createObjectURL(file);
+    let currentTime = new Date();
+    element.download = `resume-${currentTime.getTime()}.json`;
+    document.body.appendChild(element); // Required for this to work in FireFox
+    element.click();
+  };
+
   useEffect(() => {
     if (!resumeLoading && resume !== null) {
       const interval = setInterval(() => {
@@ -107,6 +146,14 @@ const LeftPanel = ({ check, handleThemeToggle }) => {
       <NavBar />
       <div className="w-full h-full flex flex-col">
         <Header check={check} handleThemeToggle={handleThemeToggle} />
+        <Button
+          variant="contained"
+          color="primary"
+          sx={{ width: "30%" }}
+          onClick={exportResumeToJSON}
+        >
+          Export JSON
+        </Button>
         <div className="w-full h-full overflow-y-scroll no-scrollbar ">
           <div className="w-4/5 mx-auto">
             {sectionsList.map((section, index) => {


### PR DESCRIPTION
Closes #87 

**Implementation**

1. Clone the latest copy of resume from redux state.
2. Dump it into a JSON file using blobbed string. 
3. Download the URL thus generated.

**Note**: Please fix the style of the "Export JSON" button it looks horrible the way I did it. 