### PR TITLE
Add app drawer for resume options like download, import, export

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,10 +13,7 @@ import { ThemeProvider, createTheme } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import Cookies from "universal-cookie";
 
-import FileDownloadIcon from "@mui/icons-material/FileDownload";
-import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
-import SchemaIcon from "@mui/icons-material/Schema";
-import { Tooltip, Fade } from "@mui/material";
+import ResumeDrawer from "./components/ResumeDrawer";
 
 const store = configureStore({
   reducer: {
@@ -97,35 +94,7 @@ const App = () => {
               <RightPanel />
 
               {/* Resume toolbar to provides options for exporting, importing and download */}
-              <div className="flex justify-center items-center dark:bg-neutral-900 bg-neutral-200/40 rounded-3xl z-20 w-1/4 p-3 space-x-5">
-                <Tooltip
-                  title="Import JSON"
-                  placement="top"
-                  arrow
-                  TransitionComponent={Fade}
-                  TransitionProps={{ timeout: 800 }}
-                >
-                  <SchemaIcon />
-                </Tooltip>
-                <Tooltip
-                  title="Export JSON"
-                  placement="top"
-                  arrow
-                  TransitionComponent={Fade}
-                  TransitionProps={{ timeout: 800 }}
-                >
-                  <FileDownloadIcon />
-                </Tooltip>
-                <Tooltip
-                  title="Download PDF"
-                  placement="top"
-                  arrow
-                  TransitionComponent={Fade}
-                  TransitionProps={{ timeout: 800 }}
-                >
-                  <PictureAsPdfIcon />
-                </Tooltip>
-              </div>
+              <ResumeDrawer />
             </div>
           </div>
         </ThemeProvider>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,11 @@ import { ThemeProvider, createTheme } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import Cookies from "universal-cookie";
 
+import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
+import SchemaIcon from "@mui/icons-material/Schema";
+import { Tooltip, Fade } from "@mui/material";
+
 const store = configureStore({
   reducer: {
     uploadImage: uploadReducer,
@@ -88,8 +93,39 @@ const App = () => {
               />
             </div>
             {/* Right side of screen for showing the rendered resume and template selection */}
-            <div className="flex-none w-1/2">
+            <div className="flex flex-col space-y-5 justify-center items-center w-1/2 border-l">
               <RightPanel />
+
+              {/* Resume toolbar to provides options for exporting, importing and download */}
+              <div className="flex justify-center items-center dark:bg-neutral-900 bg-neutral-200/40 rounded-3xl z-20 w-1/4 p-3 space-x-5">
+                <Tooltip
+                  title="Import JSON"
+                  placement="top"
+                  arrow
+                  TransitionComponent={Fade}
+                  TransitionProps={{ timeout: 800 }}
+                >
+                  <SchemaIcon />
+                </Tooltip>
+                <Tooltip
+                  title="Export JSON"
+                  placement="top"
+                  arrow
+                  TransitionComponent={Fade}
+                  TransitionProps={{ timeout: 800 }}
+                >
+                  <FileDownloadIcon />
+                </Tooltip>
+                <Tooltip
+                  title="Download PDF"
+                  placement="top"
+                  arrow
+                  TransitionComponent={Fade}
+                  TransitionProps={{ timeout: 800 }}
+                >
+                  <PictureAsPdfIcon />
+                </Tooltip>
+              </div>
             </div>
           </div>
         </ThemeProvider>

--- a/frontend/src/components/LeftPanel/LeftPanel.js
+++ b/frontend/src/components/LeftPanel/LeftPanel.js
@@ -16,13 +16,8 @@ import {
   volunteerSectionConfig,
   workExperienceSectionConfig,
 } from "../../config/sectionConfig";
-import { useDispatch, useSelector } from "react-redux";
-import { putSectionThunk } from "../../services/resume-thunk";
-import { Button } from "@mui/material";
 
 const LeftPanel = ({ check, handleThemeToggle }) => {
-  let { resume, resumeLoading } = useSelector((state) => state.resume);
-
   const sectionsList = [
     {
       type: "Basics",
@@ -74,86 +69,11 @@ const LeftPanel = ({ check, handleThemeToggle }) => {
     },
   ];
 
-  const dispatch = useDispatch();
-
-  const removeKeyFromObject = (obj, key) => {
-    if (typeof obj !== "object" || obj === null) {
-      return obj;
-    }
-
-    if (Array.isArray(obj)) {
-      obj.forEach(function (item) {
-        removeKeyFromObject(item, key);
-      });
-    } else {
-      for (var prop in obj) {
-        if (obj.hasOwnProperty(prop)) {
-          if (prop === key) {
-            delete obj[prop];
-          } else {
-            removeKeyFromObject(obj[prop], key);
-          }
-        }
-      }
-    }
-
-    return obj;
-  };
-
-  const exportResumeToJSON = () => {
-    let resumeClone = JSON.parse(JSON.stringify(resume));
-    let cleanedResume = removeKeyFromObject(resumeClone, "_id");
-    cleanedResume = removeKeyFromObject(cleanedResume, "__v");
-    const resumeJSON = JSON.stringify(cleanedResume, null, 4);
-    const element = document.createElement("a");
-    const file = new Blob([resumeJSON], { type: "application/json" });
-    element.href = URL.createObjectURL(file);
-    let currentTime = new Date();
-    element.download = `resume-${currentTime.getTime()}.json`;
-    document.body.appendChild(element); // Required for this to work in FireFox
-    element.click();
-  };
-
-  useEffect(() => {
-    if (!resumeLoading && resume !== null) {
-      const interval = setInterval(() => {
-        let resumeLocalStorage = localStorage.getItem("resume");
-        if (resumeLocalStorage !== JSON.stringify(resume)) {
-          const resumeLocalStorageObject = JSON.parse(resumeLocalStorage);
-
-          Object.keys(resumeLocalStorageObject).map((key) => {
-            if (
-              JSON.stringify(resumeLocalStorageObject[key]) !==
-              JSON.stringify(resume[key])
-            ) {
-              let section_name = key;
-              let section = {};
-              section[key] = resume[key];
-              dispatch(putSectionThunk({ section_name, section }));
-            }
-
-            return null;
-          });
-        }
-      }, 3000);
-
-      return () => clearInterval(interval);
-    }
-  }, [resume, resumeLoading]);
-
   return (
     <div className="w-full h-full flex flex-row">
       <NavBar />
       <div className="w-full h-full flex flex-col">
         <Header check={check} handleThemeToggle={handleThemeToggle} />
-        <Button
-          variant="contained"
-          color="primary"
-          sx={{ width: "30%" }}
-          onClick={exportResumeToJSON}
-        >
-          Export JSON
-        </Button>
         <div className="w-full h-full overflow-y-scroll no-scrollbar ">
           <div className="w-4/5 mx-auto">
             {sectionsList.map((section, index) => {

--- a/frontend/src/components/ResumeDrawer.js
+++ b/frontend/src/components/ResumeDrawer.js
@@ -1,0 +1,111 @@
+import React, { useEffect } from "react";
+import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
+import SchemaIcon from "@mui/icons-material/Schema";
+import { Tooltip, Fade } from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { putSectionThunk } from "../services/resume-thunk";
+
+const ResumeDrawer = () => {
+  const dispatch = useDispatch();
+  let { resume, resumeLoading } = useSelector((state) => state.resume);
+
+  const removeKeyFromObject = (obj, key) => {
+    if (typeof obj !== "object" || obj === null) {
+      return obj;
+    }
+
+    if (Array.isArray(obj)) {
+      obj.forEach(function (item) {
+        removeKeyFromObject(item, key);
+      });
+    } else {
+      for (var prop in obj) {
+        if (obj.hasOwnProperty(prop)) {
+          if (prop === key) {
+            delete obj[prop];
+          } else {
+            removeKeyFromObject(obj[prop], key);
+          }
+        }
+      }
+    }
+
+    return obj;
+  };
+
+  useEffect(() => {
+    if (!resumeLoading && resume !== null) {
+      const interval = setInterval(() => {
+        let resumeLocalStorage = localStorage.getItem("resume");
+        if (resumeLocalStorage !== JSON.stringify(resume)) {
+          const resumeLocalStorageObject = JSON.parse(resumeLocalStorage);
+
+          Object.keys(resumeLocalStorageObject).map((key) => {
+            if (
+              JSON.stringify(resumeLocalStorageObject[key]) !==
+              JSON.stringify(resume[key])
+            ) {
+              let section_name = key;
+              let section = {};
+              section[key] = resume[key];
+              dispatch(putSectionThunk({ section_name, section }));
+            }
+
+            return null;
+          });
+        }
+      }, 3000);
+
+      return () => clearInterval(interval);
+    }
+  }, [resume, resumeLoading]);
+
+  const exportResumeToJSON = () => {
+    let resumeClone = JSON.parse(JSON.stringify(resume));
+    let cleanedResume = removeKeyFromObject(resumeClone, "_id");
+    cleanedResume = removeKeyFromObject(cleanedResume, "__v");
+    const resumeJSON = JSON.stringify(cleanedResume, null, 4);
+    const element = document.createElement("a");
+    const file = new Blob([resumeJSON], { type: "application/json" });
+    element.href = URL.createObjectURL(file);
+    let currentTime = new Date();
+    element.download = `resume-${currentTime.getTime()}.json`;
+    document.body.appendChild(element); // Required for this to work in FireFox
+    element.click();
+  };
+
+  return (
+    <div className="flex justify-center items-center dark:bg-neutral-900 bg-neutral-200/40 rounded-3xl z-20 w-1/4 p-3 space-x-5">
+      <Tooltip
+        title="Import JSON"
+        placement="top"
+        arrow
+        TransitionComponent={Fade}
+        TransitionProps={{ timeout: 800 }}
+      >
+        <SchemaIcon />
+      </Tooltip>
+      <Tooltip
+        title="Export JSON"
+        placement="top"
+        arrow
+        TransitionComponent={Fade}
+        TransitionProps={{ timeout: 800 }}
+      >
+        <FileDownloadIcon onClick={exportResumeToJSON} />
+      </Tooltip>
+      <Tooltip
+        title="Download PDF"
+        placement="top"
+        arrow
+        TransitionComponent={Fade}
+        TransitionProps={{ timeout: 800 }}
+      >
+        <PictureAsPdfIcon />
+      </Tooltip>
+    </div>
+  );
+};
+
+export default ResumeDrawer;

--- a/frontend/src/components/RightPanel/RightPanel.js
+++ b/frontend/src/components/RightPanel/RightPanel.js
@@ -2,7 +2,14 @@ import React from "react";
 import Resume from "./resumes/template-1/Resume";
 
 const RightPanel = () => {
-  return <Resume />;
+  return (
+    <div className="w-11/12 h-[90vh] mx-auto border">
+      <div>
+        {/* This will act as the base container which will get zoomed in/out. The parent div has fixed width and height. */}
+        <Resume />
+      </div>
+    </div>
+  );
 };
 
 export default RightPanel;


### PR DESCRIPTION
Closes #117 
Closes #114 

## Implementation
- Add a parent container with fixed height and width for resume to render
- Add an app drawer for the functionalities like download resume, import and export json

**Note**: Creating another issue to shift the **Export JSON** functionality from left panel to app drawer _